### PR TITLE
商品詳細ページ（マークアップ）の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,3 +4,4 @@
 @import "reset";
 @import "modules/items";
 @import "modules/purchase_comfirmation";
+@import "show";

--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -89,7 +89,6 @@
       }
     }
   }
-  }
 }
 
 .mainVisual {

--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -1,6 +1,7 @@
 * {
   box-sizing: border-box;
   font-family: "Source Sans Pro", Helvetica, Arial, "游ゴシック体", "YuGothic", "メイリオ", "Meiryo", sans-serif;
+  
 }
 
 .top {

--- a/app/assets/stylesheets/modules/purchase_comfirmation.scss
+++ b/app/assets/stylesheets/modules/purchase_comfirmation.scss
@@ -72,7 +72,7 @@ main {
         }
       }
       &--btn {
-        .buy_btn {
+        .buyBtn {
           width: 400px;
           background-color: #3CCACE;
           border: none;

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -1,0 +1,104 @@
+.header__category {
+  border-top: solid 1px lightgray;
+  height: 50px;
+  padding: 15px 50px;
+  font-size: 14px;
+  box-shadow: 0 3px 6px -5px rgba(0, 0, 0, 0.5);
+}
+
+.main-show {
+  height: 1800px;
+  overflow: scroll;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  .itemDetail {
+    background-color: white;
+    position: absolute;
+    width: 700px;
+    top: 40px;
+    bottom: 40px;
+    &__box {
+      border: solid 1px lightgray;
+      padding: 30px 100px;
+      text-align: center;
+      &__title {
+        font-size: 20px;
+        font-weight: bold;
+        padding-bottom: 20px;
+      }
+      &__price {
+        padding-bottom: 20px;
+        .itemprice {
+          font-size: 40px;
+        }
+        .taxPostage {
+          font-size: 13px;
+        }
+      }
+      ul {
+        display: flex;
+        justify-content: center;
+        li {
+          margin: 10px;
+        }
+      }
+      &__introduction {
+        text-align: left;
+        margin: 20px;
+      }
+      table {
+        border: solid 1px lightgray;
+        tr {
+          border-bottom: solid 1px lightgray;
+          th {
+            width:150px;
+            padding: 15px;
+            text-align: center;
+            background-color: rgba(233, 227, 227, 0.87);
+          }
+          td {
+            width: 400px;
+            padding: 15px;
+            text-align: left;
+          }
+        }
+      }
+      &__comment {
+        margin-top: 50px;
+        font-size: 13px;
+        color: rgba(158, 155, 155, 0.726);
+        .commentText {
+          height: 100px;
+          width: 500px;
+          border-radius: 5px;
+        }
+        .commentBtn {
+          width: 400px;
+          margin-top: 20px;
+          background-color: #3CCACE;
+          border: none;
+          outline: none;
+          padding: 10px 0;
+          border-radius: 20px;
+          font-size: 18px;
+        }
+      }
+      &--btn {
+        border-bottom: solid 1px lightgray;
+        height: 80px;
+        margin-top: 30px;
+        .purchaseBtn {
+          width: 400px;
+          background-color: rgba(255, 0, 0, 0.884);
+          color: white;
+          border: none;
+          outline: none;
+          padding: 10px 0;
+          border-radius: 20px;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,6 +5,9 @@ class ItemsController < ApplicationController
   def new
   end
 
+  def show
+  end
+
   #商品購入確認（仮）
   def purchase_comfirmation
   end

--- a/app/views/items/_bottom.html.haml
+++ b/app/views/items/_bottom.html.haml
@@ -37,6 +37,6 @@
           %a.item お知らせ
     = link_to image_tag ("material/logo/logo-white.png"), class: "footer__logo"
     %p.copyright ©︎FURIMA
-  = link_to "#", class: "sellBtn" do
+  = link_to new_item_path, class: "sellBtn" do
     %p.sellBtn__text 出品する
     = image_tag ("material/icon/icon_camera.png"), class: "sellBtn__icon" 

--- a/app/views/items/purchase_comfirmation.html.haml
+++ b/app/views/items/purchase_comfirmation.html.haml
@@ -29,7 +29,7 @@
         .buyItem__box__address__change
           =link_to '変更', "#"
       .buyItem__box--btn
-        =submit_tag("購入する", class: 'buy_btn')
+        =submit_tag("購入する", class: 'buyBtn')
 
 %footer
   %list

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,0 +1,128 @@
+.wrapper
+.top
+  .header
+    .header__top
+      = link_to image_tag("material/logo/logo.png", class: "header__top__logo"), root_path
+      .header__top__search
+        %input{ class: "header__top__search__form", placeholder: "キーワードから探す"}
+        %button.header__top__search__btn 
+          = image_tag ("material/icon/icon-search 1.png"), class: "header__top__search__btn__icon" 
+    .header__bottom
+      .header__bottom__nav__left
+        .header__bottom__nav__left__category
+          カテゴリー
+        .header__bottom__nav__left__brand
+          ブランド
+      .header__bottom__nav__right
+        - if user_signed_in?
+          .header__bottom__nav__right__mypage
+            =link_to "マイページ", "#"
+          .header__bottom__nav__right__logout
+            =link_to "ログアウト", destroy_user_session_path, method: :delete
+        - else
+          .header__bottom__nav__right__login
+            =link_to "ログイン", new_user_session_path
+          .header__bottom__nav__right__registration
+            =link_to "新規会員登録", new_user_registration_path
+.header__category
+  FURIMA > 家電・スマホ・カメラ > スマートフォン/携帯電話 > スマートフォン携帯
+
+.main-show
+  .itemDetail
+    .itemDetail__box
+      .itemDetail__box__title
+        【新品・未使用】iPhone 6 Gold 16GB
+      .itemDetail__box__image
+        = image_tag("material/pict/pict-reason-02.jpg", width: 400,height: 400, class: "item__image")
+      %ul.imagelist
+        %li.images
+          = image_tag("material/pict/pict-reason-02.jpg", width: 100,height: 100, class: "item__image")
+        %li.images
+          = image_tag("material/pict/pict-reason-02.jpg", width: 100,height: 100, class: "item__image")
+      .itemDetail__box__price
+        %h1.itemprice ¥6,900
+        %span.taxPostage (税込)送料込み
+      .itemDetail__box__introduction
+        【商品説明】
+        %br
+        本体と箱の出品です。
+        docomoにて購入しました。
+        %br
+        ■機種名:iPhene 6
+        %br
+        ■カラー:Gold
+        %br
+        ■要領:16GB
+      %table
+        %tr
+          %th 出品者
+          %td 太郎
+        %tr
+          %th カテゴリー
+          %td 家電・スマホ・カメラ > スマートフォン/携帯電話 > スマートフォン本体
+        %tr
+          %th ブランド
+          %td Apple
+        %tr
+          %th 商品のサイズ
+          %td
+        %tr
+          %th 商品の状態
+          %td 新品/未使用
+        %tr 
+          %th 配送料の負担
+          %td 送料込み(出品者負担)
+        %tr
+          %th 発送元の地域
+          %td 北海道
+        %tr
+          %th 発送日の目安
+          %td 1~2日で発送
+
+      .itemDetail__box--btn
+        =submit_tag("購入手続きへ", class: 'purchaseBtn')
+    
+      .itemDetail__box__comment
+        =form_with local: true do |f|
+          = f.text_area :comment, class: 'commentText'
+          相手のことを考え、丁寧なコメントを心掛けましょう。
+          %br
+          不快な言葉遣いなどは利用制限や退会処分となることがあります。
+          = f.submit "コメントする（未実装）", class: 'commentBtn'
+
+
+
+.bottomDl
+  .bottomDl__content
+    .bottomDl__content__title
+      だれでもかんたん、人生を変えるフリマアプリ
+    .bottomDl__content__text
+      今すぐ無料ダウンロード！
+    .bottomDl__content__icon
+    = link_to image_tag ("material/icon/Download_on_the_App_Store_Badge_US-UK_RGB_blk_092917.svg"), class: "icon--app"
+    = link_to image_tag ("material/icon/google-play-badge.png"), class: "icon--google"
+.footer
+  .footer__overview
+    .footer__overview__list
+      %h2.title FURIMAについて
+      %p.list
+        %a.item 会社概要(運営会社)
+        %a.item プライバシーポリシー
+        %a.item FURIMA利用規約
+        %a.item ポイントに関する特約
+    .footer__overview__list
+      %h2.title FURIMAを見る
+      %p.list
+        %a.item カテゴリー一覧
+        %a.item ブランド一覧
+    .footer__overview__list
+      %h2.title ヘルプ&ガイド
+      %p.list
+        %a.item FURIMAガイド
+        %a.item FURIMAロゴ利用ガイドライン
+        %a.item お知らせ
+  = link_to image_tag ("material/logo/logo-white.png"), class: "footer__logo"
+  %p.copyright ©︎FURIMA
+= link_to new_item_path, class: "sellBtn" do
+  %p.sellBtn__text 出品する
+  = image_tag ("material/icon/icon_camera.png"), class: "sellBtn__icon"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     post 'addresses', to: 'users/registrations#create_address'
   end
   root 'items#index'
-  resources :items, only: [:index, :new] do
+  resources :items, only: [:index, :new, :show] do
     collection do
       get 'purchase_comfirmation'
     end


### PR DESCRIPTION
# What
商品詳細ページのビュー実装。
(コメントや商品説明で行が増えた場合のために、overflow: scroll;設定しました。)
→https://gyazo.com/0152165de163bc392da7c91982b3b3f6

# Why
商品一覧表示から商品詳細ページに飛べるように作成。　