### PR TITLE
削除機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -49,7 +49,7 @@ class ItemsController < ApplicationController
   def destroy
     @item = Item.find(params[:id])
     if @item.destroy
-      redirect_to item_path, notice: "削除しました"
+      redirect_to root_path, notice: "削除しました"
     else
       render :new
     end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -102,7 +102,7 @@
               = @item.day[:name]
 
         .itemDetail__box--btn          
-          - if user_signed_in? && (current_user.id == @item.user_id)            
+          - if user_signed_in? && current_user.id == @item.user_id            
             = link_to "商品の編集", edit_item_path,  class: 'purchaseBtn__edit'            
             = link_to "この商品を削除する", item_path(@item.id), class: 'purchaseBtn', method: :delete
           - if user_signed_in? && (current_user.id != @item.user_id)            


### PR DESCRIPTION
# What
出品した商品の削除機能を実装しました。

# Why
詳細ページから出品した本人だけが削除できなければならない。出品した本人かどうかの条件分岐は他のメンバーがすでに実装済であったため、部分的に修正して削除できる状態にする必要があった。